### PR TITLE
Force the use of Node 12

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "scripts": {
     "test": "mocha --reporter list"
   },


### PR DESCRIPTION
[Discordjs version 12 requires node 12 to work.](https://discord.js.org/#/docs/main/stable/general/welcome)
With those modification the node modules won't install if the node version installed is not equal or greater than 12.0.0.